### PR TITLE
Centralize Calendly link configuration and add /book redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ All commands are run from the root of the project, from a terminal:
 | `yarn astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `yarn astro -- --help` | Get help using the Astro CLI                     |
 
+## 🔗 Project Configuration
+
+- **Calendly link management**: Update the booking link in [`src/config/links.ts`](src/config/links.ts). The `CALENDLY_URL` constant is imported wherever the Calendly scheduler is referenced so changes propagate automatically.
+- **Vercel redirect**: Incoming traffic to `/book` is permanently redirected to the Calendly scheduler via [`vercel.json`](vercel.json). Adjust the destination there if the booking flow changes.
+
 ## 👀 Want to learn more?
 
 Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -23,6 +23,7 @@
           <a
             href="https://www.linkedin.com/company/crown-acquisition-group"
             target="_blank"
+            rel="noopener noreferrer"
             class="text-secondary-500 hover:text-secondary-400 transition-colors"
           >
             <span class="sr-only">LinkedIn</span>

--- a/src/components/sections/ContactSection.astro
+++ b/src/components/sections/ContactSection.astro
@@ -1,5 +1,6 @@
 ---
 // Contact section component for the landing page
+import { CALENDLY_URL } from "../../config/links";
 ---
 
 <section id="contact" class="py-20 bg-primary-900">
@@ -12,7 +13,7 @@
         Book a call or send us a message.
       </p>
       <div class="flex flex-col sm:flex-row justify-center gap-4">
-        <a href="https://calendly.com/mhachicha-crownacquisitiongroup" class="inline-block bg-secondary-500 hover:bg-secondary-600 text-primary-900 font-semibold py-3 px-6 rounded-lg transition-colors">Schedule a call</a>
+        <a href={CALENDLY_URL} class="inline-block bg-secondary-500 hover:bg-secondary-600 text-primary-900 font-semibold py-3 px-6 rounded-lg transition-colors">Schedule a call</a>
       </div>
     </div>
     

--- a/src/components/sections/HeroSection.astro
+++ b/src/components/sections/HeroSection.astro
@@ -1,6 +1,7 @@
 ---
 import MicroProofElement from "./MicroProofElement.astro";
 import PulseBeams from "../ui/PulseBeams.astro";
+import { CALENDLY_URL } from "../../config/links";
 ---
 
 <section class="relative bg-gradient-to-b from-primary-800 to-primary-900 text-white pt-20 pb-10">
@@ -38,7 +39,7 @@ import PulseBeams from "../ui/PulseBeams.astro";
           <!-- Pulse Beams Background Animation -->
           <PulseBeams
             showButton={true}
-            buttonLink="https://calendly.com/mhachicha-crownacquisitiongroup"
+            buttonLink={CALENDLY_URL}
             buttonText="Connect the dots"
             buttonClass="btn border border-secondary-400 hover:bg-secondary-500 hover:text-primary-900 text-secondary-300 px-8 py-3 rounded-md transition-all"
           />

--- a/src/components/sections/PricingSection.astro
+++ b/src/components/sections/PricingSection.astro
@@ -3,6 +3,7 @@
 import { Image } from 'astro:assets';
 import checkGoldSvg from '../../assets/check-gold.svg';
 import checkBlueSvg from '../../assets/check-blue.svg';
+import { CALENDLY_URL } from '../../config/links';
 ---
 
 <section id="pricing" class="py-20 bg-primary-900">
@@ -165,7 +166,7 @@ import checkBlueSvg from '../../assets/check-blue.svg';
       <p class="text-center text-4xl text-secondary-500 mb-1 font-heading font-bold">Not sure which plan is right for you?</p>
       <p class="text-center text-xl text-white mb-3">We can scope an a la carte plan for you based on your current situation</p>
       <div class="flex flex-wrap justify-center gap-4">
-        <a href="https://calendly.com/mhachicha-crownacquisitiongroup" target="_blank" class="inline-block bg-secondary-500 hover:bg-secondary-600 text-primary-900 font-medium py-3 px-6 rounded-lg transition-colors shadow-md">
+        <a href={CALENDLY_URL} target="_blank" rel="noopener noreferrer" class="inline-block bg-secondary-500 hover:bg-secondary-600 text-primary-900 font-medium py-3 px-6 rounded-lg transition-colors shadow-md">
           <div class="flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -173,7 +174,7 @@ import checkBlueSvg from '../../assets/check-blue.svg';
             <span>Get a Scope</span>
           </div>
         </a>
-        <a href="https://tally.so/r/3EGbZA" target="_blank" class="group inline-block bg-primary-800 hover:bg-secondary-500 text-white hover:text-primary-900 border-2 border-secondary-500 font-medium py-3 px-6 rounded-lg transition-colors shadow-md">
+        <a href="https://tally.so/r/3EGbZA" target="_blank" rel="noopener noreferrer" class="group inline-block bg-primary-800 hover:bg-secondary-500 text-white hover:text-primary-900 border-2 border-secondary-500 font-medium py-3 px-6 rounded-lg transition-colors shadow-md">
           <div class="flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-secondary-500 group-hover:text-primary-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/src/components/sections/SocialProofSection.astro
+++ b/src/components/sections/SocialProofSection.astro
@@ -1,5 +1,5 @@
 ---
-
+import { CALENDLY_URL } from "../../config/links";
 ---
 
 <section id="social-proof" class="py-16 bg-secondary-50">
@@ -107,7 +107,7 @@
 
       <div class="text-center mt-12">
         <a
-          href="https://calendly.com/mhachicha-crownacquisitiongroup"
+          href={CALENDLY_URL}
           class="inline-block bg-primary-700 hover:bg-primary-600 text-white font-medium py-3 px-6 rounded-lg transition-colors"
         >
           Get Financial Clarity

--- a/src/components/sections/WhatWeFixSection.astro
+++ b/src/components/sections/WhatWeFixSection.astro
@@ -1,4 +1,5 @@
 ---
+import { CALENDLY_URL } from "../../config/links";
 ---
 
 <section id="what-we-fix" class="py-12 bg-primary-900">
@@ -112,7 +113,7 @@
       >
         <h2 class="text-4xl md:text-5xl font-bold mb-4 text-secondary-400">Want to get a financial diagnosis?</h2>
         <p class="text-2xl text-white mb-10">Let's take a look under the hood, no strings attached.</p>
-        <a href="https://calendly.com/mhachicha-crownacquisitiongroup" class="inline-block bg-primary-700 hover:bg-primary-600 text-white font-bold py-4 px-8 rounded-lg transition-colors shadow-lg text-lg hover:scale-105 transform">
+        <a href={CALENDLY_URL} class="inline-block bg-primary-700 hover:bg-primary-600 text-white font-bold py-4 px-8 rounded-lg transition-colors shadow-lg text-lg hover:scale-105 transform">
           Book a Call
         </a>
       </div>

--- a/src/components/ui/PulseBeams.astro
+++ b/src/components/ui/PulseBeams.astro
@@ -181,6 +181,7 @@ const {
         <a
           href={buttonLink}
           target="_blank"
+          rel="noopener noreferrer"
           class={`pulse-button ${buttonClass} no-underline group cursor-pointer relative shadow-2xl shadow-zinc-900 rounded-full p-px text-xs font-semibold leading-6 text-white inline-flex items-center justify-center`}
         >
           <span class="inline-flex items-center justify-center text-sm sm:text-base md:text-lg font-medium">

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -1,0 +1,1 @@
+export const CALENDLY_URL = "https://calendly.com/mhachicha-crownag/20min?utm_source=website&utm_medium=booking&utm_campaign=general";

--- a/vercel.json
+++ b/vercel.json
@@ -25,5 +25,12 @@
         }
       ]
     }
+  ],
+  "redirects": [
+    {
+      "source": "/book",
+      "destination": "https://calendly.com/mhachicha-crownag/20min?utm_source=website&utm_medium=booking&utm_campaign=general",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add a shared CALENDLY_URL constant in src/config/links.ts and update components to consume it
- ensure external Calendly buttons open safely in new tabs with noopener rel attributes
- document the booking link location and configure a permanent /book redirect in vercel.json

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123d926b548326838575e1f8b5bf98)